### PR TITLE
change vship repo to codeberg and add vulkan build if hipcc and nvcc not found

### DIFF
--- a/setup/encoders.sh
+++ b/setup/encoders.sh
@@ -50,7 +50,7 @@ install_encoders() {
         log_info "Compiling FFVship..."
         
         if [ -d "Vship" ]; then rm -rf Vship; fi
-        git clone https://github.com/Line-fr/Vship.git
+        git clone https://codeberg.org/Line-fr/Vship.git
         cd Vship
         
         if command -v nvcc &> /dev/null; then
@@ -58,8 +58,8 @@ install_encoders() {
         elif command -v hipcc &> /dev/null; then
             make build
         else
-            log_warn "Neither nvcc nor hipcc found. Attempting CUDA build anyway."
-            make buildcuda
+            log_warn "Neither nvcc nor hipcc found. Attempting Vulkan build."
+            make buildVulkan
         fi
 
         log_info "Building FFVship CLI..."

--- a/setup/ffvship.sh
+++ b/setup/ffvship.sh
@@ -13,7 +13,7 @@ install_ffvship() {
         cd build_tmp || exit 1
 
         if [ -d "Vship" ]; then rm -rf Vship; fi
-        git clone https://github.com/Line-fr/Vship.git || { log_error "Failed to clone Vship"; cd ..; return 1; }
+        git clone https://codeberg.org/Line-fr/Vship.git || { log_error "Failed to clone Vship"; cd ..; return 1; }
         cd Vship || { log_error "Failed to cd into Vship"; cd ..; cd ..; return 1; }
         
         if command -v nvcc &> /dev/null; then
@@ -21,8 +21,8 @@ install_ffvship() {
         elif command -v hipcc &> /dev/null; then
             make build || { log_error "FFVship build failed"; cd ..; cd ..; return 1; }
         else
-            log_warn "Neither nvcc nor hipcc found. Attempting CUDA build anyway."
-            make buildcuda || { log_error "FFVship buildcuda failed (no compiler?)"; cd ..; cd ..; return 1; }
+            log_warn "Neither nvcc nor hipcc found. Attempting Vulkan build."
+            make buildVulkan || { log_error "FFVship buildVulkan failed (no Vulkan SDK?)"; cd ..; cd ..; return 1; }
         fi
 
         make buildFFVSHIP || { log_error "FFVship make buildFFVSHIP failed"; cd ..; cd ..; return 1; }


### PR DESCRIPTION
Currently the installer points to the wrong repository, one that is outdated
the new repo also now has vulkan build possible so I added that as a fallback instead of cuda build that is doomed to fail.

Also, for some reason there are 2 places where the setup code is in...